### PR TITLE
Feature/label record update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "settings",
         "tests",
         "README",
-        "app"
+        "app",
+        "logs"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Total updates: 1
 Sleeping for 60 seconds...
 ```
 
+By adding the following tags to the target application's compose file, information tags will be set on the containers with the commit that forced the last deployment and the number of updates bulckan has performed to maintain parity:
+
+```
+    labels:
+      - "bulckan.deploy.update_count=${UPDATE_COUNT}"
+      - "bulckan.deploy.last_commit=${LAST_COMMIT}"
+```
+
 # Multiple deployment configuration
 
 bulckan can be deployed multiple times, so it can point to different repositories and keep different applications updated and deployed at the same time.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This project provides a GitOps tool for Docker Compose on a Docker container.
 
 The application clones a GitHub repository, periodically checks for changes to a specific branch and path, and deploys or updates the project using Docker Compose.
 
+At the end of each time interval, in addition to checking for changes and updating the deployment, it re-runs the initial command so that if a service has been removed, it is redeployed while maintaining parity between the deployment on the host and the compose files on Github.
+
+bulckan will show in the logs all the steps to deploy the compose file. It will also store and log the name specified in compose, the last commit that forced the deployment or update on the host, and the number of times it has been updated due to changes on GitHub.
+
 ## Requirements:
 - Docker
 - Docker Compose
@@ -126,7 +130,7 @@ services:
 ....
 ```
 
-Bulckan deployment:
+bulckan deployment:
 
 ```
 docker-compose -f docker-compose.example.yml up -d

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -6,6 +6,7 @@
 .vscode/
 .github/
 .repo/
+.record/
 
 # files
 .env

--- a/app/bulckan.sh
+++ b/app/bulckan.sh
@@ -109,7 +109,7 @@ deploy() {
     
     # Show the current update count, last deployed commit hash, and name
     echo "Compose name: $(<"$NAME_FILE")"
-    echo "Last deployed commit: $(<"$LAST_COMMIT_FILE")"
+    echo "Commit deployed: $(<"$LAST_COMMIT_FILE")"
     echo "Total updates: $(<"$UPDATE_COUNT_FILE")"
     
     cd "repo/$GITHUB_PATH" && docker-compose up -d --build

--- a/app/bulckan.sh
+++ b/app/bulckan.sh
@@ -107,11 +107,19 @@ deploy() {
     local name_value=$(get_name_value)
     echo "$name_value" > "$NAME_FILE"
     
+    # Load the update count and last commit into variables
+    local update_count=$(<"$UPDATE_COUNT_FILE")
+    local last_commit=$(<"$LAST_COMMIT_FILE")
+    
+    # Export these variables for use in docker-compose.yml
+    export UPDATE_COUNT="$update_count"
+    export LAST_COMMIT="$last_commit"
+    
     # Show the current update count, last deployed commit hash, and name
     echo "Compose name: $(<"$NAME_FILE")"
-    echo "Commit deployed: $(<"$LAST_COMMIT_FILE")"
-    echo "Total updates: $(<"$UPDATE_COUNT_FILE")"
-    
+    echo "Commit deployed: $LAST_COMMIT"
+    echo "Total updates: $UPDATE_COUNT"
+
     cd "repo/$GITHUB_PATH" && docker-compose up -d --build
     cd ../..
 }


### PR DESCRIPTION
The application stores the commit that forced the update, the number of times the deployment has been updated, and the name set in the compose. All of the above is displayed per terminal, and the commit and update data is set as variables to be used in the target compose that is  to to set information labels on the containers.

By adding the following tags to the target application's compose file, information tags will be set on the containers with the commit that forced the last deployment and the number of updates bulckan has performed to maintain parity:

```
    labels:
      - "bulckan.deploy.update_count=${UPDATE_COUNT}"
      - "bulckan.deploy.last_commit=${LAST_COMMIT}"
```